### PR TITLE
Add public vsomeip3 interface library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,6 @@ cc_binary(
     name = "libvsomeip3.so",
     linkshared = True,
     linkstatic = True,
-    visibility = ["//visibility:public"],
     deps = [
         "//implementation",
     ],
@@ -10,25 +9,18 @@ cc_binary(
 
 cc_binary(
     name = "libvsomeip3-cfg.so.3",
-    linkopts = [
-        "-Wl,-rpath=\\$$ORIGIN",
-    ],
     linkshared = True,
     linkstatic = True,
-    visibility = ["//visibility:public"],
     deps = [
         "//implementation:configuration",
     ],
+    visibility = ["//test:__subpackages__"],
 )
 
 cc_binary(
     name = "libvsomeip3-e2e.so.3",
-    linkopts = [
-        "-Wl,-rpath=\\$$ORIGIN",
-    ],
     linkshared = True,
     linkstatic = True,
-    visibility = ["//visibility:public"],
     deps = [
         "//implementation:e2e_protection",
     ],
@@ -36,12 +28,8 @@ cc_binary(
 
 cc_binary(
     name = "libvsomeip3-sd.so.3",
-    linkopts = [
-        "-Wl,-rpath=\\$$ORIGIN",
-    ],
     linkshared = True,
     linkstatic = True,
-    visibility = ["//visibility:public"],
     deps = [
         "//implementation:service_discovery",
     ],
@@ -54,5 +42,13 @@ filegroup(
         "libvsomeip3-e2e.so.3",
         "libvsomeip3-sd.so.3",
     ],
+)
+
+cc_library(
+    name = "vsomeip3",
+    srcs = [":libvsomeip3.so"],
+    deps = ["//interface"],
+    data = [":vsomeip3-plugins"],
     visibility = ["//visibility:public"],
+    linkstatic = True, # no object files
 )

--- a/examples/hello_world/BUILD
+++ b/examples/hello_world/BUILD
@@ -14,14 +14,10 @@ cc_binary(
     name = "hello_world_service",
     srcs = [
         "hello_world_service_main.cpp",
-        "//:libvsomeip3.so"
     ],
     deps = [
         ":vsomeip_hello_world_service",
-        "//interface",
-    ],
-    data = [
-        "//:vsomeip3-plugins"
+        "//:vsomeip3"
     ],
     linkopts = [
         "-Wl,-rpath=\\$$ORIGIN/../..,--disable-new-dtags",
@@ -32,14 +28,10 @@ cc_binary(
     name = "hello_world_client",
     srcs = [
         "hello_world_client_main.cpp",
-        "//:libvsomeip3.so"
     ],
     deps = [
         ":vsomeip_hello_world_client",
-        "//interface",
-    ],
-    data = [
-        "//:vsomeip3-plugins"
+        "//:vsomeip3"
     ],
     linkopts = [
         "-Wl,-rpath=\\$$ORIGIN/../..,--disable-new-dtags",

--- a/implementation/BUILD
+++ b/implementation/BUILD
@@ -57,7 +57,7 @@ cc_library(
             "configuration/src/*.cpp",
         ],
     ),
-    visibility = ["//visibility:public"],
+    visibility = ["//:__pkg__"],
     deps = [
         ":helper",
         ":includes",
@@ -74,7 +74,7 @@ cc_library(
             "service_discovery/src/*.cpp",
         ],
     ),
-    visibility = ["//visibility:public"],
+    visibility = ["//:__pkg__"],
     deps = [
         ":helper",
         ":includes",
@@ -90,7 +90,7 @@ cc_library(
             "e2e_protection/src/*.cpp",
         ],
     ),
-    visibility = ["//visibility:public"],
+    visibility = ["//:__pkg__"],
     deps = [
         ":helper",
         ":includes",
@@ -121,7 +121,7 @@ cc_library(
         "-lpthread",
         "-ldl",
     ],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__pkg__"],
     deps = [
         ":helper",
         ":includes",

--- a/interface/BUILD
+++ b/interface/BUILD
@@ -6,5 +6,5 @@ cc_library(
         ],
     ),
     include_prefix = ".",
-    visibility = ["//visibility:public"],
+    visibility = ["//implementation:__pkg__", "//:__pkg__"],
 )

--- a/test/configuration_tests/BUILD
+++ b/test/configuration_tests/BUILD
@@ -10,16 +10,14 @@ cc_test(
     name = "configuration-test",
     srcs = [
         "configuration-test.cpp",
-        "//:libvsomeip3.so",
         "//:libvsomeip3-cfg.so.3",
     ],
     data = [
         ":configuration-test-files",
-        "//:vsomeip3-plugins",
     ],
     defines = ["VSOMEIP_CLEAN_INCLUDES"],
     deps = [
-        "//interface",
+        "//:vsomeip3",
         "//implementation:includes",
         "@googletest//:gtest",
     ],


### PR DESCRIPTION
This adds vsomeip3 as the one and only public interface library target, making all other targets private.