### PR TITLE
use lambda instead of std::ptr_fun

### DIFF
--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -2551,7 +2551,7 @@ void configuration_impl::trim(std::string &_s) {
         std::find_if(
             _s.begin(),
             _s.end(),
-            std::not1(std::ptr_fun(isspace))
+            [](unsigned char ch) { return !std::isspace(ch); }
         )
     );
 
@@ -2559,7 +2559,7 @@ void configuration_impl::trim(std::string &_s) {
         std::find_if(
             _s.rbegin(),
             _s.rend(),
-            std::not1(std::ptr_fun(isspace))).base(),
+            [](unsigned char ch) { return !std::isspace(ch); }).base(),
             _s.end()
     );
 }


### PR DESCRIPTION
Changes to allow compilation with -std=c++17.

This fix was made in the upstream repo, but was a part of a massive commit, so couldn't be cherry-picked ([configuration_impl.cpp:3020](https://github.com/COVESA/vsomeip/blob/819ca58f1647b6f7244cf98a5bda03aef18d372c/implementation/configuration/src/configuration_impl.cpp#L3020))