### PR TITLE
Add more explanatory logging

### DIFF
--- a/implementation/routing/src/routing_manager_client.cpp
+++ b/implementation/routing/src/routing_manager_client.cpp
@@ -2104,6 +2104,9 @@ void routing_manager_client::on_subscribe_ack(client_t _client, service_t _servi
             << std::setw(4) << _eventgroup << "."
             << std::setw(4) << _event;
 #endif
+    VSOMEIP_INFO << "routing_manager_client::" << __func__ << ": Received subscription ACK for ["
+                 << std::hex << std::setfill('0') << std::setw(4) << _service << "." << std::setw(4) << _instance << "."
+                 << std::setw(4) << _eventgroup << "." << std::setw(4) << _event << "]";
     if (_event == ANY_EVENT) {
         auto its_eventgroup = find_eventgroup(_service, _instance, _eventgroup);
         if (its_eventgroup) {
@@ -2119,6 +2122,9 @@ void routing_manager_client::on_subscribe_ack(client_t _client, service_t _servi
 void routing_manager_client::on_subscribe_nack(client_t _client, service_t _service, instance_t _instance, eventgroup_t _eventgroup,
                                                event_t _event) {
     (void)_client;
+    VSOMEIP_INFO << "routing_manager_client::" << __func__ << ": Received subscription NACK for ["
+                 << std::hex << std::setfill('0') << std::setw(4) << _service << "." << std::setw(4) << _instance << "."
+                 << std::setw(4) << _eventgroup << "." << std::setw(4) << _event << "]";
     if (_event == ANY_EVENT) {
         auto its_eventgroup = find_eventgroup(_service, _instance, _eventgroup);
         if (its_eventgroup) {

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -63,6 +63,27 @@
 
 namespace vsomeip_v3 {
 
+namespace {
+
+const char* message_type_to_string(message_type_e _type) {
+    switch (_type) {
+    case message_type_e::MT_REQUEST:
+        return "request";
+    case message_type_e::MT_REQUEST_NO_RETURN:
+        return "request_no_return";
+    case message_type_e::MT_NOTIFICATION:
+        return "notification";
+    case message_type_e::MT_RESPONSE:
+        return "response";
+    case message_type_e::MT_ERROR:
+        return "error";
+    default:
+        return "other";
+    }
+}
+
+}
+
 #ifdef ANDROID
 namespace sd {
 runtime::~runtime() { }
@@ -670,6 +691,12 @@ void routing_manager_impl::subscribe(client_t _client, const vsomeip_sec_client_
                     // is available before subscribing via SD otherwise we sent
                     // a StopSubscribe/Subscribe once the first offer is received
                     if (its_info && (!subscriber_is_rm_host || find_service(_service, _instance))) {
+                        VSOMEIP_INFO << "SUBSCRIBE(" << std::hex << std::setfill('0') << std::setw(4) << _client
+                                     << "): sending SD subscribe for [" << std::setw(4) << _service << "."
+                                     << std::setw(4) << _instance << "." << std::setw(4)
+                                     << _eventgroup << ":" << std::setw(4) << _event << ":" << std::dec
+                                     << static_cast<uint16_t>(_major) << "]"
+                                     << " selective=" << std::boolalpha << its_info->is_selective();
                         discovery_->subscribe(_service, _instance, _eventgroup, _major, configured_ttl,
                                               its_info->is_selective() ? _client : VSOMEIP_ROUTING_CLIENT, its_info);
                     }
@@ -731,7 +758,11 @@ void routing_manager_impl::unsubscribe(client_t _client, const vsomeip_sec_clien
             }
 
             if (its_info && (last_subscriber_removed || its_info->is_selective())) {
-
+                VSOMEIP_INFO << "UNSUBSCRIBE(" << std::hex << std::setfill('0') << std::setw(4) << _client
+                             << "): sending SD unsubscribe for [" << std::setw(4) << _service << "." << std::setw(4) << _instance
+                             << "." << std::setw(4) << _eventgroup << "." << std::setw(4) << _event << "]"
+                             << " selective=" << std::boolalpha << its_info->is_selective()
+                             << " last_subscriber_removed=" << last_subscriber_removed;
                 discovery_->unsubscribe(_service, _instance, _eventgroup, its_info->is_selective() ? _client : VSOMEIP_ROUTING_CLIENT);
             }
         } else {
@@ -1274,6 +1305,14 @@ void routing_manager_impl::on_message(const byte_t* _data, length_t _size, endpo
     const method_t its_method = bithelper::read_uint16_be(&_data[VSOMEIP_METHOD_POS_MIN]);
     const client_t its_client = bithelper::read_uint16_be(&_data[VSOMEIP_CLIENT_POS_MIN]);
     const session_t its_session = bithelper::read_uint16_be(&_data[VSOMEIP_SESSION_POS_MIN]);
+
+    if (its_message_type == message_type_e::MT_RESPONSE || its_message_type == message_type_e::MT_ERROR) {
+        VSOMEIP_DEBUG << "Received remote " << message_type_to_string(its_message_type) << " ["
+                      << std::hex << std::setfill('0') << std::setw(4) << its_service << "." << std::setw(4) << its_method
+                      << "." << std::setw(4) << its_client << "." << std::setw(4) << its_session << "] from "
+                      << _remote_address.to_string() << ":" << std::dec << _remote_port << " via "
+                      << (_receiver->is_local() ? "local" : (_receiver->is_reliable() ? "tcp" : "udp"));
+    }
 
     // refer to error workflow in PRS_SOMEIP_00195
     // (although note that it is *NOT* strictly followed!)

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -42,6 +42,35 @@
 
 namespace vsomeip_v3 {
 
+namespace {
+
+const char* availability_state_to_string(availability_state_e _state) {
+    switch (_state) {
+    case availability_state_e::AS_AVAILABLE:
+        return "available";
+    case availability_state_e::AS_UNAVAILABLE:
+        return "unavailable";
+    case availability_state_e::AS_UNKNOWN:
+    default:
+        return "unknown";
+    }
+}
+
+const char* subscription_state_to_string(subscription_state_e _state) {
+    switch (_state) {
+    case subscription_state_e::SUBSCRIPTION_ACKNOWLEDGED:
+        return "acknowledged";
+    case subscription_state_e::SUBSCRIPTION_NOT_ACKNOWLEDGED:
+        return "not_acknowledged";
+    case subscription_state_e::IS_SUBSCRIBING:
+        return "subscribing";
+    default:
+        return "unknown";
+    }
+}
+
+}
+
 #ifdef ANDROID
 configuration::~configuration() { }
 #endif
@@ -1546,6 +1575,11 @@ void application_impl::set_availability_state(availability_state_t& _availabilit
 void application_impl::on_availability(service_t _service, instance_t _instance, availability_state_e _state, major_version_t _major,
                                        minor_version_t _minor, availability_reason_e _reason) {
 
+    VSOMEIP_INFO << "application_impl::" << __func__ << ": Service [" << std::hex << std::setfill('0') << std::setw(4) << _service
+                 << "." << std::setw(4) << _instance << ":" << std::dec << static_cast<uint32_t>(_major) << "." << _minor
+                 << "] changed availability to " << availability_state_to_string(_state)
+                 << " reason=" << static_cast<uint32_t>(_reason);
+
     std::vector<availability_state_handler_t> its_handlers;
     {
         std::scoped_lock availability_lock{availability_mutex_};
@@ -1645,6 +1679,7 @@ void application_impl::on_availability(service_t _service, instance_t _instance,
         }
     }
     if (_state == availability_state_e::AS_UNAVAILABLE) {
+        bool had_subscription_state(false);
         {
             std::scoped_lock its_lock{subscriptions_mutex_};
             auto found_service = subscriptions_.find(_service);
@@ -1665,6 +1700,7 @@ void application_impl::on_availability(service_t _service, instance_t _instance,
             if (its_service != subscriptions_state_.end()) {
                 auto its_instance = its_service->second.find(_instance);
                 if (its_instance != its_service->second.end()) {
+                    had_subscription_state = true;
                     for (auto& its_eventgroup : its_instance->second) {
                         for (auto& its_event : its_eventgroup.second) {
                             its_event.second = subscription_state_e::SUBSCRIPTION_NOT_ACKNOWLEDGED;
@@ -1672,6 +1708,11 @@ void application_impl::on_availability(service_t _service, instance_t _instance,
                     }
                 }
             }
+        }
+        if (had_subscription_state) {
+            VSOMEIP_INFO << "application_impl::" << __func__ << ": Reset subscription state for unavailable service ["
+                         << std::hex << std::setfill('0') << std::setw(4) << _service << "." << std::setw(4) << _instance
+                         << "] to not acknowledged.";
         }
     }
 
@@ -1710,7 +1751,7 @@ void application_impl::on_message(std::shared_ptr<message>&& _message) {
         if (!check_for_active_subscription(its_service, its_instance, static_cast<event_t>(its_method))) {
             VSOMEIP_INFO << "application_impl::on_message [" << std::hex << std::setfill('0') << std::setw(4) << its_service << "."
                          << std::setw(4) << its_instance << "." << std::setw(4) << its_method << "]"
-                         << ": blocked as the subscription is already inactive.";
+                         << ": blocked as the subscription is already inactive or no longer acknowledged.";
             return;
         }
     }
@@ -2397,6 +2438,7 @@ bool application_impl::check_subscription_state(service_t _service, instance_t _
 
     bool is_acknowledged(false);
     bool should_subscribe(true);
+    subscription_state_e its_state(subscription_state_e::SUBSCRIPTION_NOT_ACKNOWLEDGED);
     {
         bool has_found(false);
 
@@ -2409,6 +2451,7 @@ bool application_impl::check_subscription_state(service_t _service, instance_t _
                 if (its_eventgroup != its_instance->second.end()) {
                     auto its_event = its_eventgroup->second.find(_event);
                     if (its_event != its_eventgroup->second.end()) {
+                        its_state = its_event->second;
                         if (its_event->second != subscription_state_e::SUBSCRIPTION_NOT_ACKNOWLEDGED) {
                             has_found = true;
 
@@ -2426,7 +2469,19 @@ bool application_impl::check_subscription_state(service_t _service, instance_t _
 
         if (!has_found) {
             subscriptions_state_[_service][_instance][_eventgroup][_event] = subscription_state_e::IS_SUBSCRIBING;
+            its_state = subscription_state_e::IS_SUBSCRIBING;
         }
+    }
+
+    if (should_subscribe) {
+        VSOMEIP_INFO << "application_impl::" << __func__ << ": Subscribing to [" << std::hex << std::setfill('0')
+                     << std::setw(4) << _service << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
+                     << "." << std::setw(4) << _event << "]";
+    } else {
+        VSOMEIP_DEBUG << "application_impl::" << __func__ << ": Reusing existing subscription state "
+                      << subscription_state_to_string(its_state) << " for [" << std::hex << std::setfill('0')
+                      << std::setw(4) << _service << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
+                      << "." << std::setw(4) << _event << "]";
     }
 
     if (!should_subscribe && is_acknowledged) {

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -45,6 +45,24 @@
 namespace vsomeip_v3 {
 namespace sd {
 
+namespace {
+
+const char* reliability_type_to_string(reliability_type_e _type) {
+    switch (_type) {
+    case reliability_type_e::RT_RELIABLE:
+        return "reliable";
+    case reliability_type_e::RT_UNRELIABLE:
+        return "unreliable";
+    case reliability_type_e::RT_BOTH:
+        return "both";
+    case reliability_type_e::RT_UNKNOWN:
+    default:
+        return "unknown";
+    }
+}
+
+}
+
 service_discovery_impl::service_discovery_impl(service_discovery_host* _host, const std::shared_ptr<configuration>& _configuration) :
     io_(_host->get_io()), host_(_host), configuration_(_configuration), port_(VSOMEIP_SD_DEFAULT_PORT), reliable_(false),
     serializer_(std::make_shared<serializer>(configuration_->get_buffer_shrink_threshold())),
@@ -997,13 +1015,21 @@ void service_discovery_impl::on_message(const byte_t* _data, length_t _length, c
     std::lock_guard<std::recursive_mutex> its_subscribed_lock(subscribed_mutex_);
 
     if (is_suspended_) {
+        VSOMEIP_INFO << "service_discovery_impl::" << __func__ << ": Ignoring SD message from " << _sender.to_string()
+                     << " because service discovery is suspended.";
         return;
     }
 
     // ignore all SD messages with source address equal to node's unicast address
     if (!check_source_address(_sender)) {
+        VSOMEIP_DEBUG << "service_discovery_impl::" << __func__ << ": Ignoring SD message from own source address "
+                      << _sender.to_string();
         return;
     }
+
+    VSOMEIP_DEBUG << "service_discovery_impl::" << __func__ << ": Received SD message from " << _sender.to_string()
+                  << " via " << (_is_multicast ? "multicast" : "unicast") << " (" << std::dec << _length
+                  << " bytes)";
 
     if (_is_multicast) {
         static bool must_start_last_msg_received_timer(true);
@@ -1023,6 +1049,8 @@ void service_discovery_impl::on_message(const byte_t* _data, length_t _length, c
     if (its_message) {
         // ignore all messages which are sent with invalid header fields
         if (!check_static_header_fields(its_message)) {
+            VSOMEIP_WARNING << "service_discovery_impl::" << __func__ << ": Ignoring SD message from " << _sender.to_string()
+                            << " because the static header fields are invalid.";
             return;
         }
 
@@ -1154,7 +1182,8 @@ void service_discovery_impl::on_message(const byte_t* _data, length_t _length, c
             serialize_and_send(its_resubscribes, _sender);
         }
     } else {
-        VSOMEIP_ERROR << "service_discovery_impl::" << __func__ << ": Deserialization error.";
+        VSOMEIP_ERROR << "service_discovery_impl::" << __func__ << ": Deserialization error for SD message from "
+                      << _sender.to_string() << " via " << (_is_multicast ? "multicast" : "unicast") << ".";
         return;
     }
 }
@@ -1298,6 +1327,10 @@ void service_discovery_impl::process_serviceentry(std::shared_ptr<serviceentry_i
             VSOMEIP_ERROR << __func__ << ": Unsupported service entry type";
         }
     } else if (its_type != entry_type_e::FIND_SERVICE && (_sd_ac_state.sd_acceptance_required_ || _sd_ac_state.accept_entries_)) {
+        VSOMEIP_INFO << "service_discovery_impl::" << __func__ << ": Processing stop offer for [" << std::hex << std::setfill('0')
+                     << std::setw(4) << its_service << "." << std::setw(4) << its_instance << "]"
+                     << " reliable=" << std::boolalpha << (its_reliable_port != ILLEGAL_PORT)
+                     << " unreliable=" << (its_unreliable_port != ILLEGAL_PORT);
         // stop sending find service in repetition phase
         update_request(its_service, its_instance);
 
@@ -1327,8 +1360,11 @@ void service_discovery_impl::process_offerservice_serviceentry(service_t _servic
         && ((_reliable_port != ILLEGAL_PORT && !configuration_->is_secure_port(_reliable_address, _reliable_port, true))
             || (_unreliable_port != ILLEGAL_PORT && !configuration_->is_secure_port(_unreliable_address, _unreliable_port, false)))) {
 
-        VSOMEIP_WARNING << __func__ << ": Ignoring offer of [" << std::hex << std::setfill('0') << std::setw(4) << _service << "."
-                        << std::setw(4) << _instance << "]";
+        VSOMEIP_WARNING << __func__ << ": Ignoring secure offer for [" << std::hex << std::setfill('0') << std::setw(4) << _service
+                        << "." << std::setw(4) << _instance
+                        << "] because at least one advertised endpoint is not configured as secure."
+                        << " reliable=" << _reliable_address.to_string() << ":" << std::dec << _reliable_port
+                        << " unreliable=" << _unreliable_address.to_string() << ":" << _unreliable_port;
         return;
     }
 
@@ -1340,7 +1376,8 @@ void service_discovery_impl::process_offerservice_serviceentry(service_t _servic
 
     if (offer_type == reliability_type_e::RT_UNKNOWN) {
         VSOMEIP_WARNING << __func__ << ": Unknown remote offer type [" << std::hex << std::setfill('0') << std::setw(4) << _service << "."
-                        << std::setw(4) << _instance << "]";
+                        << std::setw(4) << _instance << "] reliable=" << _reliable_address.to_string() << ":" << std::dec
+                        << _reliable_port << " unreliable=" << _unreliable_address.to_string() << ":" << _unreliable_port;
         return; // Unknown remote offer type --> no way to access it!
     }
 
@@ -1353,7 +1390,8 @@ void service_discovery_impl::process_offerservice_serviceentry(service_t _servic
                 VSOMEIP_WARNING << "service_discovery_impl::process_offerservice_serviceentry"
                                 << ": Do not accept offer [" << std::hex << std::setfill('0') << std::setw(4) << _service << "."
                                 << std::setw(4) << _instance << "]"
-                                << " from " << _address.to_string() << ":" << std::dec << _port << " reliable=" << _reliable;
+                                << " from " << _address.to_string() << ":" << std::dec << _port << " reliable=" << _reliable
+                                << " because SD acceptance rejected this protected port.";
                 remove_remote_offer_type_by_ip(_address, _port, _reliable);
                 host_->expire_subscriptions(_address, _port, _reliable);
                 host_->expire_services(_address, _port, _reliable);
@@ -1393,6 +1431,12 @@ void service_discovery_impl::process_offerservice_serviceentry(service_t _servic
 
     if (update_remote_offer_type(_service, _instance, offer_type, _reliable_address, _reliable_port, _unreliable_address, _unreliable_port,
                                  _received_via_multicast)) {
+        VSOMEIP_INFO << __func__ << ": Accepted offer [" << std::hex << std::setfill('0') << std::setw(4) << _service << "."
+                     << std::setw(4) << _instance << ":" << std::dec << static_cast<std::uint32_t>(_major) << "." << _minor
+                     << "] ttl=" << _ttl << " transport=" << reliability_type_to_string(offer_type)
+                     << " reliable=" << _reliable_address.to_string() << ":" << _reliable_port
+                     << " unreliable=" << _unreliable_address.to_string() << ":" << _unreliable_port
+                     << " via " << (_received_via_multicast ? "multicast" : "unicast");
         VSOMEIP_WARNING << __func__ << ": Remote offer type changed [" << std::hex << std::setfill('0') << std::setw(4) << _service << "."
                         << std::setw(4) << _instance << "]";
         // Only update eventgroup reliability type if it was initially unknown
@@ -2059,8 +2103,9 @@ void service_discovery_impl::handle_eventgroup_subscription(
         VSOMEIP_WARNING << __func__ << ": Subscription for [" << std::hex << std::setfill('0') << std::setw(4) << _service << "."
                         << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup << "]"
                         << " not valid: Event configuration (" << static_cast<std::uint32_t>(_info->get_reliability())
-                        << ") does not match the provided endpoint options: " << _first_address.to_string() << ":" << std::dec
-                        << _first_port << " " << _second_address.to_string() << ":" << _second_port;
+                        << ") does not match the provided endpoint options from sender " << _sender.to_string() << ": "
+                        << _first_address.to_string() << ":" << std::dec << _first_port << " "
+                        << _second_address.to_string() << ":" << _second_port;
         return;
     }
 
@@ -2078,6 +2123,10 @@ void service_discovery_impl::handle_eventgroup_subscription(
         }
         if (send_nack) {
             insert_subscription_ack(_acknowledgement, _info, 0, nullptr, _clients);
+            VSOMEIP_WARNING << __func__ << ": Rejecting subscription for [" << std::hex << std::setfill('0') << std::setw(4) << _service
+                            << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
+                            << "] from sender " << _sender.to_string()
+                            << " because the service is not accepting remote subscriptions from this sender.";
             return;
         }
     }
@@ -2114,7 +2163,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
                     VSOMEIP_ERROR << "TCP connection to target1: [" << its_reliable->get_address().to_string() << ":"
                                   << its_reliable->get_port() << "] not established for subscription to: [" << std::hex << std::setfill('0')
                                   << std::setw(4) << _service << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
-                                  << "] ";
+                                  << "] sender=" << _sender.to_string();
                     return;
                 }
             } else { // udp unicast
@@ -2133,7 +2182,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
                     VSOMEIP_ERROR << "TCP connection to target2 : [" << its_reliable->get_address().to_string() << ":"
                                   << its_reliable->get_port() << "] not established for subscription to: [" << std::hex << std::setfill('0')
                                   << std::setw(4) << _service << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
-                                  << "] ";
+                                  << "] sender=" << _sender.to_string();
                     return;
                 }
             } else { // udp unicast
@@ -2155,6 +2204,10 @@ void service_discovery_impl::handle_eventgroup_subscription(
         }
         if (insert_nack) {
             insert_subscription_ack(_acknowledgement, _info, 0, nullptr, _clients);
+            VSOMEIP_WARNING << __func__ << ": Rejecting subscription for [" << std::hex << std::setfill('0') << std::setw(4) << _service
+                            << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
+                            << "] because SD acceptance rejected one of the protected subscriber endpoints."
+                            << " sender=" << _sender.to_string();
             return;
         }
     }
@@ -2170,6 +2223,9 @@ void service_discovery_impl::handle_eventgroup_subscription(
 
         if (_ttl == 0) { // --> unsubscribe
             its_subscription->set_ttl(0);
+            VSOMEIP_INFO << __func__ << ": Received unsubscribe for [" << std::hex << std::setfill('0') << std::setw(4) << _service
+                         << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup << "] from sender "
+                         << _sender.to_string();
             if (!_is_stop_subscribe_subscribe) {
                 {
                     std::lock_guard<std::mutex> its_lock(pending_remote_subscriptions_mutex_);
@@ -2185,6 +2241,13 @@ void service_discovery_impl::handle_eventgroup_subscription(
             its_subscription->set_force_initial_events(true);
         }
         its_subscription->set_ttl(_ttl * get_ttl_factor(_service, _instance, ttl_factor_subscriptions_));
+
+        VSOMEIP_INFO << __func__ << ": Received subscribe for [" << std::hex << std::setfill('0') << std::setw(4) << _service
+                     << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup << "] ttl=" << std::dec << _ttl
+                     << " sender=" << _sender.to_string() << " reliable="
+                     << (its_reliable ? its_reliable->get_address().to_string() + ":" + std::to_string(its_reliable->get_port()) : "n/a")
+                     << " unreliable="
+                     << (its_unreliable ? its_unreliable->get_address().to_string() + ":" + std::to_string(its_unreliable->get_port()) : "n/a");
 
         {
             std::lock_guard<std::mutex> its_lock(pending_remote_subscriptions_mutex_);
@@ -2211,6 +2274,9 @@ void service_discovery_impl::handle_eventgroup_subscription_nack(service_t _serv
             if (found_eventgroup != found_instance->second.end()) {
                 auto its_subscription = found_eventgroup->second;
                 for (const auto its_client : _clients) {
+                    VSOMEIP_INFO << __func__ << ": Subscription NACK for client 0x" << std::hex << std::setfill('0')
+                                 << std::setw(4) << its_client << " [" << std::setw(4) << _service << "."
+                                 << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup << "]";
                     host_->on_subscribe_nack(its_client, _service, _instance, _eventgroup, true, PENDING_SUBSCRIPTION_ID);
                 }
 
@@ -2248,7 +2314,7 @@ void service_discovery_impl::handle_eventgroup_subscription_ack(service_t _servi
                             << std::setw(4) << its_client << "): ["
                             << std::setw(4) << _service << "."
                             << std::setw(4) << _instance << "."
-                            << std::setw(4) << _eventgroup << "]";
+                            << std::setw(4) << _eventgroup << "] from sender " << _sender.to_string();
 
                         host_->on_subscribe_ack(its_client, _service, _instance, _eventgroup, ANY_EVENT, PENDING_SUBSCRIPTION_ID);
                     }


### PR DESCRIPTION
# Summary

This PR adds explanatory vSomeIP logs to make SOME/IP and SOME/IP-SD debugging easier without changing behavior or configuration.

The focus is the event-driven v1 scope from the issue discussion: log what vSomeIP already knows at the point where it accepts, ignores, acknowledges, rejects, or receives something, instead of introducing new persistent state.

# What Changed

- Added SD ingress logs for received service discovery traffic, including sender and whether it arrived via multicast or unicast.
- Expanded SD offer logs so accepted offers and ignored offers include the concrete reason and endpoint context.
- Added subscription lifecycle logs for:
  - SD subscribe send
  - SD unsubscribe send
  - remote subscribe receive
  - remote unsubscribe receive
  - subscribe ACK
  - subscribe NACK
- Added application-side availability transition logs, including when subscription state is reset because a service became unavailable.
- Added debug logs for incoming remote SOME/IP responses and errors with source IP, port, and transport.

# Why

This is meant to answer the common debugging questions from the issue more directly, for example:

- whether discovery traffic is received at all
- why an offer was accepted or ignored
- when a subscribe or unsubscribe was sent
- whether a subscription was acknowledged or rejected
- why notifications are later treated as inactive
- from which remote endpoint a response was received

# Scope / Non-Goals

- No public API changes
- No new logging configuration flags
- No behavior changes in routing, SD, subscription handling, or availability handling
- No new persistent subscription-state model
- Request timeout diagnostics are not added in this PR

# Verification

- `git diff --check`
- Focused compile of the edited translation units:
  - `implementation/service_discovery/src/service_discovery_impl.cpp.o`
  - `implementation/routing/src/routing_manager_impl.cpp.o`
  - `implementation/routing/src/routing_manager_client.cpp.o`
  - `implementation/runtime/src/application_impl.cpp.o`
