### PR TITLE
Clean-up dependencies

### DIFF
--- a/implementation/BUILD
+++ b/implementation/BUILD
@@ -107,6 +107,7 @@ cc_library(
     deps = [
         ":generated_config",
         ":helper",
+        "@boost//:headers",
         "//interface",
         "@boost//:filesystem",
     ],

--- a/interface/BUILD
+++ b/interface/BUILD
@@ -8,8 +8,5 @@ cc_library(
     ),
     strip_include_prefix = ".",
     tags = ["same-ros-pkg-as: @vsomeip//:vsomeip3"],
-    visibility = [
-        "//:__pkg__",
-        "//implementation:__pkg__",
-    ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
- Add missing but used `@boost//:headers`
- Make `vsomeip/interface` public, so downstream targets can depend on to directly receive headers