### PR TITLE
Fix SOME/IP subscription management

### DIFF
--- a/documentation/placeholder_subscription_fixes.md
+++ b/documentation/placeholder_subscription_fixes.md
@@ -1,0 +1,31 @@
+# Placeholder subscription fixes
+
+## Specific-event placeholder upgrade
+
+When a subscription for a specific event arrives before its provider has
+registered that event, the routing manager creates a cache-placeholder event
+and stores the subscriber in its eventgroup.
+
+If the provider subsequently registers the event without explicit eventgroups,
+vSomeIP derives the eventgroup from the notifier ID. Previously, that upgrade
+used `event::set_eventgroups`, which replaced the existing client set for that
+eventgroup. Consequently, a subscription whose eventgroup equals the notifier
+ID was silently removed.
+
+The upgrade now uses `event::add_eventgroup`. It creates the implicit
+eventgroup when needed while preserving subscribers already held by the
+placeholder.
+
+## ANY_EVENT placeholder transfer
+
+The public eventgroup-subscription API defaults to `ANY_EVENT`. If such a
+subscription arrived before the provider registered an event, the routing
+manager stored it in an `ANY_EVENT` cache placeholder. On a later provider
+registration without explicit eventgroups, the real event correctly used its
+notifier ID as an implicit eventgroup, but subscriber transfer iterated the
+empty eventgroup argument instead. No subscriber was copied to the real event.
+
+Event registration now derives one effective eventgroup set before updating
+the event. The same set is used for event membership, eventgroup metadata, and
+transfer from an `ANY_EVENT` placeholder, so implicit eventgroups are handled
+the same way as explicit ones.

--- a/implementation/BUILD
+++ b/implementation/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:expand_template.bzl", "expand_template")
 load("@apex//common/bazel/rules_cc:defs.bzl", "apex_cc_library")
 load("@vsomeip//bazel:version.bzl", "version_dict_from_string")
+load("//bazel:expand_template.bzl", "expand_template")
 
-APEX_VSOMEIP_VERSION_TAG = "3.6.1-apex8-fix-qnx-gateway-com-02"  # Must match the git tag version.
+APEX_VSOMEIP_VERSION_TAG = "3.6.1-apex9-fix-subscription-management-07"  # Must match the git tag version.
 
 expand_template(
     name = "config",
@@ -57,7 +57,10 @@ apex_cc_library(
             "configuration/src/*.cpp",
         ],
     ),
-    visibility = ["//:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//test/unit_tests/routing_manager_tests:__pkg__",
+    ],
     deps = [
         ":implementation",
         "@boost//:filesystem",
@@ -71,10 +74,14 @@ apex_cc_library(
             "service_discovery/src/*.cpp",
         ],
     ),
-    visibility = ["//:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//test/unit_tests/routing_manager_tests:__pkg__",
+    ],
     deps = [
         ":implementation",
     ],
+    alwayslink = True,
 )
 
 apex_cc_library(
@@ -127,11 +134,14 @@ apex_cc_library(
         "VSOMEIP_INTERNAL_SUPPRESS_DEPRECATED",
     ],
     tags = ["same-ros-pkg-as: @vsomeip//:vsomeip3"],
-    visibility = ["//:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//test/unit_tests/routing_manager_tests:__pkg__",
+    ],
     deps = [
         ":generated_config",
         ":helper",
-        "@boost//:headers",
         "//interface",
+        "@boost//:headers",
     ],
 )

--- a/implementation/routing/include/routing_manager_base.hpp
+++ b/implementation/routing/include/routing_manager_base.hpp
@@ -167,6 +167,10 @@ protected:
                              const std::shared_ptr<debounce_filter_impl_t>& _filter, client_t _client,
                              std::set<event_t>* _already_subscribed_events);
 
+    bool add_eventgroup_subscriber(const std::shared_ptr<eventgroupinfo>& _eventgroup, eventgroup_t _eventgroup_id,
+                                   const std::shared_ptr<debounce_filter_impl_t>& _filter, client_t _client,
+                                   std::set<event_t>* _already_subscribed_events);
+
     void clear_shadow_subscriptions(void);
 
     std::shared_ptr<serializer> get_serializer();

--- a/implementation/routing/include/routing_manager_impl.hpp
+++ b/implementation/routing/include/routing_manager_impl.hpp
@@ -9,6 +9,8 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
+#include <tuple>
 #include <vector>
 #include <list>
 #include <unordered_set>
@@ -276,6 +278,33 @@ private:
     void send_subscribe(client_t _client, service_t _service, instance_t _instance, eventgroup_t _eventgroup, major_version_t _major,
                         event_t _event, const std::shared_ptr<debounce_filter_impl_t>& _filter);
 
+    // A subscription for a service provided by another local application is
+    // forwarded over the local routing socket. Unlike subscriptions made by
+    // the routing-manager host, these were previously not retained when that
+    // one-shot forwarding attempt could not be made.
+    struct local_subscription_data_t {
+        client_t client_;
+        service_t service_;
+        instance_t instance_;
+        eventgroup_t eventgroup_;
+        major_version_t major_;
+        event_t event_;
+        std::shared_ptr<debounce_filter_impl_t> filter_;
+
+        bool operator<(const local_subscription_data_t& _other) const {
+            return std::tie(client_, service_, instance_, eventgroup_, major_, event_, filter_)
+                   < std::tie(_other.client_, _other.service_, _other.instance_, _other.eventgroup_, _other.major_, _other.event_,
+                              _other.filter_);
+        }
+    };
+
+    bool forward_local_subscription(const local_subscription_data_t& _subscription);
+    void send_pending_local_subscriptions(service_t _service, instance_t _instance, major_version_t _major);
+    void schedule_pending_local_subscription_retry();
+    void retry_pending_local_subscriptions(const boost::system::error_code& _error);
+    void remove_pending_local_subscription(client_t _client, service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+                                           event_t _event);
+
     void on_net_interface_or_route_state_changed(bool _is_interface, const std::string& _if, bool _available);
 
     void start_ip_routing();
@@ -373,6 +402,15 @@ private:
 
     std::mutex remote_subscription_state_mutex_;
     std::map<std::tuple<service_t, instance_t, eventgroup_t, client_t>, subscription_state_e> remote_subscription_state_;
+
+    std::mutex pending_local_subscription_mutex_;
+    std::set<local_subscription_data_t> pending_local_subscriptions_;
+    // Entries that were replayed after an earlier forwarding failure. They are
+    // retained until unsubscribe so an unsubscribe racing with replay can be
+    // forwarded to the provider as well.
+    std::set<local_subscription_data_t> forwarded_pending_local_subscriptions_;
+    boost::asio::steady_timer pending_local_subscription_timer_;
+    bool pending_local_subscription_retry_scheduled_;
 
     std::shared_ptr<e2e::e2e_provider> e2e_provider_;
 

--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -317,6 +317,14 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
         }
     };
 
+    // An event without explicit eventgroups belongs to the eventgroup with
+    // the same ID as its notifier. Use that effective set consistently below,
+    // including when moving subscriptions from an ANY_EVENT placeholder.
+    std::set<eventgroup_t> its_eventgroups(_eventgroups);
+    if (its_eventgroups.empty()) {
+        its_eventgroups.insert(_notifier);
+    }
+
     std::shared_ptr<event> its_event = find_event(_service, _instance, _notifier);
     bool transfer_subscriptions_from_any_event(false);
     if (its_event) {
@@ -333,7 +341,7 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
                     its_event->set_shadow(false);
                     its_event->set_update_on_change(_update_on_change);
                 }
-                for (auto eg : _eventgroups) {
+                for (auto eg : its_eventgroups) {
                     its_event->add_eventgroup(eg);
                 }
                 transfer_subscriptions_from_any_event = true;
@@ -367,14 +375,8 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
             if (its_service) {
                 its_event->set_version(its_service->get_major());
             }
-            if (_eventgroups.size() == 0) { // No eventgroup specified
-                std::set<eventgroup_t> its_eventgroups;
-                its_eventgroups.insert(_notifier);
-                its_event->set_eventgroups(its_eventgroups);
-            } else {
-                for (auto eg : _eventgroups) {
-                    its_event->add_eventgroup(eg);
-                }
+            for (auto eg : its_eventgroups) {
+                its_event->add_eventgroup(eg);
             }
 
             its_event->set_epsilon_change_function(_epsilon_change_func);
@@ -395,13 +397,7 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
             its_event->set_version(its_service->get_major());
         }
 
-        if (_eventgroups.size() == 0) { // No eventgroup specified
-            std::set<eventgroup_t> its_eventgroups;
-            its_eventgroups.insert(_notifier);
-            its_event->set_eventgroups(its_eventgroups);
-        } else {
-            its_event->set_eventgroups(_eventgroups);
-        }
+        its_event->set_eventgroups(its_eventgroups);
 
         if ((_is_shadow || is_routing_manager()) && !_epsilon_change_func) {
             std::shared_ptr<debounce_filter_impl_t> its_debounce = configuration_->get_default_debounce(_service, _instance, _notifier);
@@ -508,7 +504,7 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
         std::shared_ptr<event> its_any_event = find_event(_service, _instance, ANY_EVENT);
         if (its_any_event) {
             std::set<eventgroup_t> any_events_eventgroups = its_any_event->get_eventgroups();
-            for (eventgroup_t eventgroup : _eventgroups) {
+            for (eventgroup_t eventgroup : its_eventgroups) {
                 auto found_eg = any_events_eventgroups.find(eventgroup);
                 if (found_eg != any_events_eventgroups.end()) {
                     std::set<client_t> its_any_event_subscribers = its_any_event->get_subscribers(eventgroup);
@@ -523,7 +519,7 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
         its_event->add_ref(_client, _is_provided);
     }
 
-    for (auto eg : _eventgroups) {
+    for (auto eg : its_eventgroups) {
         std::shared_ptr<eventgroupinfo> its_eventgroupinfo = find_eventgroup(_service, _instance, eg);
         if (!its_eventgroupinfo) {
             its_eventgroupinfo = std::make_shared<eventgroupinfo>();
@@ -1233,6 +1229,29 @@ bool routing_manager_base::insert_subscription(service_t _service, instance_t _i
                             << "unoffered) event. Creating placeholder event holding "
                             << "subscription until event is requested/offered.";
             is_inserted = create_placeholder_event_and_subscribe(_service, _instance, _eventgroup, _event, _filter, _client);
+
+            // create_placeholder_event_and_subscribe registers an ANY_EVENT
+            // placeholder. A provider registration can complete after the
+            // initial eventgroup lookup above but before that placeholder is
+            // populated. In that ordering the provider's one-time transfer
+            // from the placeholder has already run, so the new subscriber
+            // would otherwise remain attached only to ANY_EVENT.
+            //
+            // Serialize the reconciliation with register_event(). If the
+            // provider registration completed first, attach the subscriber to
+            // every concrete event now in the eventgroup. If it starts after
+            // this critical section, it observes the populated placeholder
+            // and performs its normal transfer.
+            std::lock_guard<std::mutex> its_registration_lock(event_registration_mutex_);
+            for (const auto& its_event : find_events(_service, _instance, _eventgroup)) {
+                if (its_event->get_event() == ANY_EVENT) {
+                    continue;
+                }
+                if (_already_subscribed_events && its_event->is_subscribed(_client)) {
+                    _already_subscribed_events->insert(its_event->get_event());
+                }
+                is_inserted = its_event->add_subscriber(_eventgroup, _filter, _client, host_->is_routing()) || is_inserted;
+            }
         }
     } else { // subscribe to all events of the eventgroup
         std::shared_ptr<eventgroupinfo> its_eventgroup = find_eventgroup(_service, _instance, _eventgroup);
@@ -1242,15 +1261,7 @@ bool routing_manager_base::insert_subscription(service_t _service, instance_t _i
             if (!its_events.size()) {
                 create_place_holder = true;
             } else {
-                for (const auto& e : its_events) {
-                    if (e->is_subscribed(_client)) {
-                        // client is already subscribed to event from eventgroup
-                        // this can happen if events are members of multiple
-                        // eventgroups
-                        _already_subscribed_events->insert(e->get_event());
-                    }
-                    is_inserted = e->add_subscriber(_eventgroup, _filter, _client, host_->is_routing()) || is_inserted;
-                }
+                is_inserted = add_eventgroup_subscriber(its_eventgroup, _eventgroup, _filter, _client, _already_subscribed_events);
             }
         } else {
             create_place_holder = true;
@@ -1263,7 +1274,33 @@ bool routing_manager_base::insert_subscription(service_t _service, instance_t _i
                             << "unoffered) eventgroup. Creating placeholder event holding "
                             << "subscription until event is requested/offered.";
             is_inserted = create_placeholder_event_and_subscribe(_service, _instance, _eventgroup, _event, _filter, _client);
+
+            // Registration may have transferred pending ANY_EVENT subscribers
+            // before this placeholder was populated, then published the concrete
+            // eventgroup while placeholder creation waited for registration to
+            // finish. Re-read the group and apply the subscription to its concrete
+            // members so the final state does not depend on that ordering.
+            its_eventgroup = find_eventgroup(_service, _instance, _eventgroup);
+            if (its_eventgroup && !its_eventgroup->get_events().empty()) {
+                is_inserted =
+                        add_eventgroup_subscriber(its_eventgroup, _eventgroup, _filter, _client, _already_subscribed_events) || is_inserted;
+            }
         }
+    }
+    return is_inserted;
+}
+
+bool routing_manager_base::add_eventgroup_subscriber(const std::shared_ptr<eventgroupinfo>& _eventgroup, eventgroup_t _eventgroup_id,
+                                                     const std::shared_ptr<debounce_filter_impl_t>& _filter, client_t _client,
+                                                     std::set<event_t>* _already_subscribed_events) {
+    bool is_inserted(false);
+    for (const auto& its_event : _eventgroup->get_events()) {
+        if (its_event->is_subscribed(_client)) {
+            // A client can already be subscribed when an event belongs to
+            // multiple eventgroups.
+            _already_subscribed_events->insert(its_event->get_event());
+        }
+        is_inserted = its_event->add_subscriber(_eventgroup_id, _filter, _client, host_->is_routing()) || is_inserted;
     }
     return is_inserted;
 }

--- a/implementation/routing/src/routing_manager_client.cpp
+++ b/implementation/routing/src/routing_manager_client.cpp
@@ -2393,21 +2393,24 @@ bool routing_manager_client::create_placeholder_event_and_subscribe(service_t _s
 
     bool is_inserted(false);
 
-    if (find_service(_service, _instance)) {
-        // We received an event for an existing service which was not yet
-        // requested/offered. Create a placeholder field until someone
-        // requests/offers this event with full information like eventgroup,
-        // field/event, etc.
-        std::set<eventgroup_t> its_eventgroups({_eventgroup});
-        // routing_manager_client: Always register with own client id and shadow = false
-        routing_manager_base::register_event(host_->get_client(), _service, _instance, _notifier, its_eventgroups, event_type_e::ET_UNKNOWN,
-                                             reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, false,
-                                             false, true);
+    // The subscription can arrive while the provider is still registering its
+    // service/events. Do not drop it just because the service record is not
+    // visible at this instant: the cache placeholder is specifically meant to
+    // retain it until the later event registration transfers the subscriber.
+    std::set<eventgroup_t> its_eventgroups({_eventgroup});
+    // routing_manager_client: Always register with own client id and shadow = false
+    routing_manager_base::register_event(host_->get_client(), _service, _instance, _notifier, its_eventgroups, event_type_e::ET_UNKNOWN,
+                                         reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, false,
+                                         false, true);
 
-        std::shared_ptr<event> its_event = find_event(_service, _instance, _notifier);
-        if (its_event) {
-            is_inserted = its_event->add_subscriber(_eventgroup, _filter, _client, false);
-        }
+    std::shared_ptr<event> its_event = find_event(_service, _instance, _notifier);
+    if (its_event) {
+        // The provider may have registered the event object but not offered it
+        // yet. In that state add_subscriber(..., false) rejects this otherwise
+        // valid local subscription and the later offer has nothing to transfer.
+        // Force the placeholder subscription into the event so the provider's
+        // registration/offer lifecycle retains it until notifications begin.
+        is_inserted = its_event->add_subscriber(_eventgroup, _filter, _client, true);
     }
 
     return is_inserted;

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -92,10 +92,11 @@ runtime::~runtime() { }
 
 routing_manager_impl::routing_manager_impl(routing_manager_host* _host) :
     routing_manager_base(_host), version_log_timer_(_host->get_io()), if_state_running_(false), sd_route_set_(false),
-    routing_running_(false), routing_state_(configuration_->get_initial_routing_state()), status_log_timer_(_host->get_io()),
-    memory_log_timer_(_host->get_io()), ep_mgr_impl_(std::make_shared<endpoint_manager_impl>(this, io_, configuration_)),
-    pending_remote_offer_id_(0), last_resume_(std::chrono::steady_clock::time_point::min()), statistics_log_timer_(_host->get_io()),
-    ignored_statistics_counter_(0) {
+    routing_running_(false), routing_state_(configuration_->get_initial_routing_state()),
+    pending_local_subscription_timer_(_host->get_io()), pending_local_subscription_retry_scheduled_(false),
+    status_log_timer_(_host->get_io()), memory_log_timer_(_host->get_io()),
+    ep_mgr_impl_(std::make_shared<endpoint_manager_impl>(this, io_, configuration_)), pending_remote_offer_id_(0),
+    last_resume_(std::chrono::steady_clock::time_point::min()), statistics_log_timer_(_host->get_io()), ignored_statistics_counter_(0) {
 
     VSOMEIP_INFO << "Starting Routing Manager [Host] with state " << routing_state_tostring(routing_state_);
 }
@@ -307,6 +308,12 @@ void routing_manager_impl::stop() {
     }
 
     {
+        std::scoped_lock its_lock{pending_local_subscription_mutex_};
+        pending_local_subscription_timer_.cancel();
+        pending_local_subscription_retry_scheduled_ = false;
+    }
+
+    {
         std::scoped_lock its_lock{statistics_log_timer_mutex_};
         statistics_log_timer_.cancel();
     }
@@ -454,6 +461,7 @@ bool routing_manager_impl::offer_service(client_t _client, service_t _service, i
         }
 
         send_pending_subscriptions(_service, _instance, _major);
+        send_pending_local_subscriptions(_service, _instance, _major);
     }
     erase_offer_command(_service, _instance);
     if (stub_)
@@ -702,9 +710,11 @@ void routing_manager_impl::subscribe(client_t _client, const vsomeip_sec_client_
                     }
                 } else {
                     its_critical.unlock();
-                    if (is_available(_service, _instance, _major) && stub_) {
-                        stub_->send_subscribe(ep_mgr_->find_local(_service, _instance), _client, _service, _instance, _eventgroup, _major,
-                                              _event, _filter, PENDING_SUBSCRIPTION_ID);
+                    const local_subscription_data_t its_subscription = {_client, _service, _instance, _eventgroup, _major, _event, _filter};
+                    std::scoped_lock its_pending_lock(pending_local_subscription_mutex_);
+                    if (!forward_local_subscription(its_subscription)) {
+                        pending_local_subscriptions_.insert(its_subscription);
+                        schedule_pending_local_subscription_retry();
                     }
                 }
             }
@@ -726,6 +736,8 @@ void routing_manager_impl::unsubscribe(client_t _client, const vsomeip_sec_clien
                  << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup << "." << std::setw(4) << _event << "]";
 
     bool last_subscriber_removed(true);
+
+    remove_pending_local_subscription(_client, _service, _instance, _eventgroup, _event);
 
     std::shared_ptr<eventgroupinfo> its_info = find_eventgroup(_service, _instance, _eventgroup);
     if (its_info) {
@@ -3216,6 +3228,95 @@ void routing_manager_impl::send_subscribe(client_t _client, service_t _service, 
     if (endpoint && stub_) {
         stub_->send_subscribe(endpoint, _client, _service, _instance, _eventgroup, _major, _event, _filter, PENDING_SUBSCRIPTION_ID);
     }
+}
+
+bool routing_manager_impl::forward_local_subscription(const local_subscription_data_t& _subscription) {
+    if (!stub_ || !is_available(_subscription.service_, _subscription.instance_, _subscription.major_)) {
+        return false;
+    }
+
+    const auto endpoint = ep_mgr_->find_local(_subscription.service_, _subscription.instance_);
+    if (!endpoint) {
+        return false;
+    }
+
+    return stub_->send_subscribe(endpoint, _subscription.client_, _subscription.service_, _subscription.instance_,
+                                 _subscription.eventgroup_, _subscription.major_, _subscription.event_, _subscription.filter_,
+                                 PENDING_SUBSCRIPTION_ID);
+}
+
+void routing_manager_impl::send_pending_local_subscriptions(service_t _service, instance_t _instance, major_version_t _major) {
+    std::scoped_lock its_lock(pending_local_subscription_mutex_);
+    for (auto its_subscription = pending_local_subscriptions_.begin(); its_subscription != pending_local_subscriptions_.end();) {
+        if (its_subscription->service_ == _service && its_subscription->instance_ == _instance
+            && its_subscription->major_ == _major && forward_local_subscription(*its_subscription)) {
+            forwarded_pending_local_subscriptions_.insert(*its_subscription);
+            its_subscription = pending_local_subscriptions_.erase(its_subscription);
+        } else {
+            ++its_subscription;
+        }
+    }
+
+    if (!pending_local_subscriptions_.empty())
+        schedule_pending_local_subscription_retry();
+}
+
+void routing_manager_impl::schedule_pending_local_subscription_retry() {
+    if (pending_local_subscription_retry_scheduled_)
+        return;
+
+    pending_local_subscription_retry_scheduled_ = true;
+    pending_local_subscription_timer_.expires_after(std::chrono::milliseconds(100));
+    pending_local_subscription_timer_.async_wait(
+            std::bind(&routing_manager_impl::retry_pending_local_subscriptions, this, std::placeholders::_1));
+}
+
+void routing_manager_impl::retry_pending_local_subscriptions(const boost::system::error_code& _error) {
+    std::scoped_lock its_lock(pending_local_subscription_mutex_);
+    pending_local_subscription_retry_scheduled_ = false;
+    if (_error)
+        return;
+
+    for (auto its_subscription = pending_local_subscriptions_.begin(); its_subscription != pending_local_subscriptions_.end();) {
+        if (forward_local_subscription(*its_subscription)) {
+            forwarded_pending_local_subscriptions_.insert(*its_subscription);
+            its_subscription = pending_local_subscriptions_.erase(its_subscription);
+        } else {
+            ++its_subscription;
+        }
+    }
+
+    if (!pending_local_subscriptions_.empty())
+        schedule_pending_local_subscription_retry();
+}
+
+void routing_manager_impl::remove_pending_local_subscription(client_t _client, service_t _service, instance_t _instance,
+                                                              eventgroup_t _eventgroup, event_t _event) {
+    std::scoped_lock its_lock(pending_local_subscription_mutex_);
+    for (auto its_subscription = pending_local_subscriptions_.begin(); its_subscription != pending_local_subscriptions_.end();) {
+        if (its_subscription->client_ == _client && its_subscription->service_ == _service
+            && its_subscription->instance_ == _instance && its_subscription->eventgroup_ == _eventgroup
+            && (_event == ANY_EVENT || its_subscription->event_ == _event)) {
+            its_subscription = pending_local_subscriptions_.erase(its_subscription);
+        } else {
+            ++its_subscription;
+        }
+    }
+    bool was_forwarded(false);
+    for (auto its_subscription = forwarded_pending_local_subscriptions_.begin();
+         its_subscription != forwarded_pending_local_subscriptions_.end();) {
+        if (its_subscription->client_ == _client && its_subscription->service_ == _service
+            && its_subscription->instance_ == _instance && its_subscription->eventgroup_ == _eventgroup
+            && (_event == ANY_EVENT || its_subscription->event_ == _event)) {
+            was_forwarded = true;
+            its_subscription = forwarded_pending_local_subscriptions_.erase(its_subscription);
+        } else {
+            ++its_subscription;
+        }
+    }
+    if (was_forwarded && stub_)
+        stub_->send_unsubscribe(ep_mgr_->find_local(_service, _instance), _client, _service, _instance, _eventgroup, _event,
+                                PENDING_SUBSCRIPTION_ID);
 }
 
 bool routing_manager_impl::is_suspended() const {

--- a/test/unit_tests/routing_manager_tests/BUILD
+++ b/test/unit_tests/routing_manager_tests/BUILD
@@ -1,0 +1,17 @@
+cc_test(
+    name = "routing_manager_tests",
+    srcs = glob([
+        "*.cpp",
+        "*.hpp",
+        "mocks/*.cpp",
+        "mocks/*.hpp",
+    ]),
+    copts = ["-Wno-error"],
+    deps = [
+        "//implementation",
+        "//implementation:configuration",
+        "//implementation:service_discovery",
+        "@boost//:headers",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit_tests/routing_manager_tests/mocks/mock_routing_manager_host.hpp
+++ b/test/unit_tests/routing_manager_tests/mocks/mock_routing_manager_host.hpp
@@ -21,7 +21,8 @@ public:
     MOCK_METHOD(boost::asio::io_context&, get_io, (), (override));
 
     MOCK_METHOD(void, on_availability,
-                (service_t _service, instance_t _instance, availability_state_e _state, major_version_t _major, minor_version_t _minor),
+                (service_t _service, instance_t _instance, availability_state_e _state, major_version_t _major, minor_version_t _minor,
+                 availability_reason_e _reason),
                 (override));
     MOCK_METHOD(void, on_state, (state_type_e _state), (override));
     MOCK_METHOD(void, on_message, (std::shared_ptr<message> && _message), (override));

--- a/test/unit_tests/routing_manager_tests/routing_manager_ut_setup.hpp
+++ b/test/unit_tests/routing_manager_tests/routing_manager_ut_setup.hpp
@@ -11,9 +11,10 @@
 #include <boost/asio.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <vsomeip/vsomeip.hpp>
 
-#include <common/utility.hpp>
-
+#include "../../../implementation/configuration/include/configuration_impl.hpp"
+#include "../../../implementation/routing/include/routing_manager_impl.hpp"
 #include "mocks/mock_routing_manager_host.hpp"
 
 class routing_manager_ut_setup : public testing::Test {

--- a/test/unit_tests/routing_manager_tests/ut_placeholder_subscriptions.cpp
+++ b/test/unit_tests/routing_manager_tests/ut_placeholder_subscriptions.cpp
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <set>
+#include <thread>
+
+#include "routing_manager_ut_setup.hpp"
+
+namespace {
+constexpr vsomeip_v3::service_t service = 0x1234;
+constexpr vsomeip_v3::instance_t instance = 0x5678;
+constexpr vsomeip_v3::event_t event_id = 0x8001;
+constexpr vsomeip_v3::client_t subscriber = 0x1001;
+
+class late_subscription_routing_manager : public vsomeip_v3::routing_manager_impl {
+public:
+    explicit late_subscription_routing_manager(vsomeip_v3::routing_manager_host* _host) : routing_manager_impl(_host) { }
+
+    bool insert_subscription_for_test(vsomeip_v3::eventgroup_t _eventgroup) {
+        std::set<vsomeip_v3::event_t> its_already_subscribed_events;
+        return insert_subscription(service, instance, _eventgroup, vsomeip_v3::ANY_EVENT, nullptr, subscriber,
+                                   &its_already_subscribed_events);
+    }
+
+    std::function<void()> before_placeholder_creation_;
+
+private:
+    bool create_placeholder_event_and_subscribe(vsomeip_v3::service_t _service, vsomeip_v3::instance_t _instance,
+                                                vsomeip_v3::eventgroup_t _eventgroup, vsomeip_v3::event_t _event,
+                                                const std::shared_ptr<vsomeip_v3::debounce_filter_impl_t>& _filter,
+                                                vsomeip_v3::client_t _client) override {
+        if (before_placeholder_creation_) {
+            before_placeholder_creation_();
+        }
+
+        const std::set<vsomeip_v3::eventgroup_t> its_eventgroups{_eventgroup};
+        register_event(host_->get_client(), _service, _instance, _event, its_eventgroups, vsomeip_v3::event_type_e::ET_UNKNOWN,
+                       vsomeip_v3::reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, false, false,
+                       true);
+
+        const auto its_placeholder = find_event(_service, _instance, _event);
+        return its_placeholder && its_placeholder->add_subscriber(_eventgroup, _filter, _client, true);
+    }
+};
+}
+
+TEST_F(routing_manager_ut_setup, preserves_specific_event_placeholder_subscriber_for_implicit_eventgroup) {
+    const std::set<vsomeip_v3::eventgroup_t> eventgroups{event_id};
+
+    its_manager->register_event(subscriber, service, instance, event_id, eventgroups, vsomeip_v3::event_type_e::ET_UNKNOWN,
+                                vsomeip_v3::reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, false,
+                                false, true);
+
+    const auto placeholder = its_manager->find_event(service, instance, event_id);
+    ASSERT_NE(nullptr, placeholder);
+    ASSERT_TRUE(placeholder->add_subscriber(event_id, nullptr, subscriber, false));
+
+    its_manager->register_event(subscriber, service, instance, event_id, {}, vsomeip_v3::event_type_e::ET_EVENT,
+                                vsomeip_v3::reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, true,
+                                false, false);
+
+    const auto registered_event = its_manager->find_event(service, instance, event_id);
+    ASSERT_NE(nullptr, registered_event);
+    EXPECT_TRUE(registered_event->has_subscriber(event_id, subscriber));
+}
+
+TEST_F(routing_manager_ut_setup, transfers_any_event_placeholder_subscriber_for_implicit_eventgroup) {
+    const std::set<vsomeip_v3::eventgroup_t> eventgroups{event_id};
+
+    its_manager->register_event(subscriber, service, instance, vsomeip_v3::ANY_EVENT, eventgroups, vsomeip_v3::event_type_e::ET_UNKNOWN,
+                                vsomeip_v3::reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, false,
+                                false, true);
+
+    const auto placeholder = its_manager->find_event(service, instance, vsomeip_v3::ANY_EVENT);
+    ASSERT_NE(nullptr, placeholder);
+    ASSERT_TRUE(placeholder->add_subscriber(event_id, nullptr, subscriber, false));
+
+    its_manager->register_event(subscriber, service, instance, event_id, {}, vsomeip_v3::event_type_e::ET_EVENT,
+                                vsomeip_v3::reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, true,
+                                false, false);
+
+    const auto registered_event = its_manager->find_event(service, instance, event_id);
+    ASSERT_NE(nullptr, registered_event);
+    EXPECT_TRUE(registered_event->has_subscriber(event_id, subscriber));
+}
+
+TEST(late_any_event_subscription, rescans_eventgroup_after_registration_overtakes_placeholder_creation) {
+    boost::asio::io_context io;
+    mock_routing_manager_host host;
+    const std::string name("LateSubscriptionRace");
+    const auto configuration = std::make_shared<vsomeip_v3::cfg::configuration_impl>("routing_manager_ut_config.json");
+
+    EXPECT_CALL(host, get_io()).WillRepeatedly(testing::ReturnRef(io));
+    EXPECT_CALL(host, get_name()).WillRepeatedly(testing::ReturnRef(name));
+    EXPECT_CALL(host, get_configuration()).WillRepeatedly(testing::Return(configuration));
+    EXPECT_CALL(host, get_client()).WillRepeatedly(testing::Return(0x2001));
+    EXPECT_CALL(host, is_routing()).WillRepeatedly(testing::Return(false));
+
+    late_subscription_routing_manager manager(&host);
+    manager.init();
+
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool subscription_chose_placeholder(false);
+    bool registration_complete(false);
+
+    manager.before_placeholder_creation_ = [&] {
+        std::unique_lock<std::mutex> lock(mutex);
+        subscription_chose_placeholder = true;
+        condition.notify_all();
+        condition.wait(lock, [&] { return registration_complete; });
+    };
+
+    std::thread registration([&] {
+        {
+            std::unique_lock<std::mutex> lock(mutex);
+            condition.wait(lock, [&] { return subscription_chose_placeholder; });
+        }
+
+        manager.register_event(0x2001, service, instance, event_id, {event_id}, vsomeip_v3::event_type_e::ET_EVENT,
+                               vsomeip_v3::reliability_type_e::RT_UNKNOWN, std::chrono::milliseconds::zero(), false, true, nullptr, true,
+                               false, false);
+
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            registration_complete = true;
+        }
+        condition.notify_all();
+    });
+
+    EXPECT_TRUE(manager.insert_subscription_for_test(event_id));
+    registration.join();
+
+    const auto registered_event = manager.find_event(service, instance, event_id);
+    ASSERT_NE(nullptr, registered_event);
+    EXPECT_TRUE(registered_event->has_subscriber(event_id, subscriber));
+
+    const auto placeholder = manager.find_event(service, instance, vsomeip_v3::ANY_EVENT);
+    ASSERT_NE(nullptr, placeholder);
+    EXPECT_TRUE(placeholder->has_subscriber(event_id, subscriber));
+
+    manager.unsubscribe(subscriber, nullptr, service, instance, event_id, vsomeip_v3::ANY_EVENT);
+    EXPECT_FALSE(registered_event->has_subscriber(event_id, subscriber));
+    EXPECT_FALSE(placeholder->has_subscriber(event_id, subscriber));
+}

--- a/test/unit_tests/routing_manager_tests/ut_set_routing_state.cpp
+++ b/test/unit_tests/routing_manager_tests/ut_set_routing_state.cpp
@@ -30,7 +30,7 @@ TEST_F(routing_manager_ut_setup, DISABLED_set_routing_state_RS_SUSPENDED) {
 
     // Called on mock_host_ as a result of routing_manager_impl::del_routing_info being called
     // within the logic tree
-    EXPECT_CALL(mock_host_, on_availability(_, _, _, _, _)).Times(AtLeast(1));
+    EXPECT_CALL(mock_host_, on_availability(_, _, _, _, _, _)).Times(AtLeast(1));
 
     // Adding a service using add_routing_info this is a local service probably need to add remotes
     // for this test


### PR DESCRIPTION
Bugs fixed by the change:

  - Subscriptions no longer disappear when a specific-event placeholder is upgraded to an event with its implicit eventgroup (eventgroup ==
    notifier). Using add_eventgroup preserves placeholder subscribers; the former set_eventgroups replacement discarded them.
  - ANY_EVENT placeholder subscriptions are now transferred when the provider registers an event without explicit eventgroups. The code
    derives the effective implicit group first and uses it consistently for transfer and group metadata.

  - A subscription that arrives while its service/event is still being registered is retained as a placeholder instead of being dropped
    because the service record is not yet visible.

  - Placeholder insertion and provider registration are reconciled under the registration lock, closing the race where registration
    completed just before placeholder population and the subscriber was never copied to concrete events.

  - Local subscriptions whose first routing-socket forward fails are queued and retried after the provider becomes available; explicit
    unsubscription removes queued work and forwards a compensating unsubscribe if replay already succeeded.
